### PR TITLE
[activationexplorer] use empty activationTimestamp for post-upgrade

### DIFF
--- a/app.js
+++ b/app.js
@@ -371,11 +371,12 @@ app.onStartup = function () {
 		const activationTimestamp = process.env.BTCEXP_ACTIVATION_TIMESTAMP;
 		// need a timestamp if this is an activationTestnet explorer
 		if (activationTimestamp == undefined) {
-			debugLog(`Please inform an activation timestamp when running with --explorer-instance \'activationTestnet\'`);
-			process.exit(1);
+			debugLog(`Running in post-upgrade mode.`);
+			global.currentActivation = -1;
+		} else {
+			global.currentActivation = moment.unix(activationTimestamp);
+			global.nextActivation = moment.unix(activationTimestamp).add(1, 'day');
 		}
-		global.currentActivation = moment.unix(activationTimestamp);
-		global.nextActivation = moment.unix(activationTimestamp).add(1, 'day');
 	}
 
 	loadChangelog();

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -28,8 +28,11 @@ html(lang="en")
 
 				if selectedExplorer.identifier == 'activationTestnet'
 					span(class="navbar-text")
-						a(href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md") activation timestamps:
-						| &nbsp; current: #{currentActivation.format('X')} / tomorrow's: #{nextActivation.format('X')}
+						if currentActivation != -1
+							a(href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md") activation timestamps:
+							| &nbsp; current: #{currentActivation.format('X')} / tomorrow's: #{nextActivation.format('X')}
+						else
+							| Upgrade has completed successfully!!!
 
 				span(class="pull-right navbar-text") hosted by 
 					a(href="https://www.bitcoincash.org") BitcoinCash.org


### PR DESCRIPTION
after upgrade is concluded, the activation testnet explorer temporarily mirrors regular testnet until release next upgrade software is released